### PR TITLE
made f32 to an Option<f32>

### DIFF
--- a/src/models/tandoor/api_tandoor_food_property.rs
+++ b/src/models/tandoor/api_tandoor_food_property.rs
@@ -15,7 +15,7 @@ pub struct ApiTandoorFoodProperty {
 impl From<InternalTandoorFoodProperty> for ApiTandoorFoodProperty{
     fn from(value: InternalTandoorFoodProperty) -> Self {
         ApiTandoorFoodProperty{
-            property_amount: value.property_amount.to_string(),
+            property_amount: value.property_amount.unwrap_or(0.0).to_string(),
             property_type: ApiTandoorProperty::from(value.property_type),
         }
     }

--- a/src/models/tandoor/internal_tandoor_food_property.rs
+++ b/src/models/tandoor/internal_tandoor_food_property.rs
@@ -5,7 +5,7 @@ use crate::models::tandoor::internal_tandoor_property::InternalTandoorProperty;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InternalTandoorFoodProperty {
     /// How much of the property is in that food.
-    pub property_amount: f32,
+    pub property_amount: Option<f32>,
     /// Definition of the property that is in that food.
     pub property_type: InternalTandoorProperty
 }


### PR DESCRIPTION
Fixes #2 by making a property value of  `null` possible in Tandoor. Sets 0.0 as a default.
While this is only a temporary fix (as 0.0 is not a very good default value) I have set it on the roadmap to make overall handling of possible null values better