### PR TITLE
Added command line parameter parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +381,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -956,6 +1002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1055,7 @@ dependencies = [
 name = "tandoor_importer"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "env_logger",
  "log",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "tandoor_importer"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandoor_importer"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ reqwest = { version = "0.12", features = ["json", "blocking"] }
 regex = "1.10.5"
 log = "0.4.21"
 env_logger = "0.11.5"
+clap = { version = "4.5.15", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use reqwest::blocking::{Client};
 use log::{debug, info, warn, error, trace};
 use env_logger;
+use clap::Parser;
 
 mod models;
 use models::configuration::Configuration;
@@ -22,12 +23,18 @@ use models::tandoor::api_tandoor_food::ApiTandoorFood;
 use models::tandoor::api_tandoor_food_property::ApiTandoorFoodProperty;
 use models::usda::usda_food::USDAFood;
 use models::usda::usda_api_response::USDAApiResponse;
+use models::command_line_arguments::Args;
 
 fn main(){
-    // Create clint for api requests.
+
+    // Get command line arguments.
+    let args = Args::parse();
+
+    // Create client for api requests.
     let client = Client::new();
 
-    env_logger::init();
+    // Initialize logger (with set log level for the crate
+    env_logger::Builder::new().filter(Some(env!("CARGO_PKG_NAME")), args.log_level.into()).init();
 
     // Read app settings
     let app_settings = fs::read_to_string("./appsettings.json").expect("The appsettings were not loaded successfully.");

--- a/src/models/command_line_arguments.rs
+++ b/src/models/command_line_arguments.rs
@@ -1,0 +1,42 @@
+//! Holds all the command line parameters and the types associated with them
+use clap::Parser;
+use log::LevelFilter;
+
+/// Struct containing all possible command line parameters.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args{
+    /// Override existing properties
+    #[arg(short, long="override", help = "When set the program overrides already present properties.")]
+    pub override_properties: bool,
+
+    /// Interactive mode
+    #[arg(short, long, help = "When set the program asks the user to enter a FDC ID when none was found.")]
+    pub interactive: bool,
+
+    /// Log level
+    #[arg(short, long, default_value = "info", help = "Sets the log level.",)]
+    pub log_level: LogLevel,
+}
+
+/// Possible log levels.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum LogLevel{
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error
+}
+
+impl Into<LevelFilter> for LogLevel{
+    fn into(self) -> LevelFilter {
+        match self {
+            LogLevel::Trace => LevelFilter::Trace,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Warning => LevelFilter::Warn,
+            LogLevel::Error => LevelFilter::Error
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,3 +2,4 @@
 pub mod tandoor;
 pub mod usda;
 pub mod configuration;
+pub mod command_line_arguments;


### PR DESCRIPTION
This PR adds command line parameter parsing and the commands specified in #8.

The log level is already set by the specified command line parameter as said in #7 

Closes #8 as the implementation of --override and --interactive is done in #9 and #6 respectively