### PR TITLE
Added the interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,24 @@ Because adding all the properties to a food by hand is quite annoying I built th
 2. Create an API key for the USDA FDC database by signing up [here](https://fdc.nal.usda.gov/api-key-signup.html). The API key will be sent to you via e-mail.
 3. Open the FDC page for every food you want to update (e.g. [this](https://fdc.nal.usda.gov/fdc-app.html#/food-details/169661/nutrients) for maple syrup) 
    - Either copy the URL into the "URL" field of the food. The field can be found by editing a food item and going to the "More" section.
-   - Or go to the admin view of your foods `<yout-tandoor-endpoint/admin/cookbook/food/` and edit the food there to enter the FDC ID.
+   - Or go to the admin view of your foods `<your-tandoor-endpoint>/admin/cookbook/food/` and edit the food there to enter the FDC ID.
    - Note that the URL will be preferred if URL and FDC ID are set.
+   - You can also run the program in interactive mode (`./tandoor_importer --interactive`) to be asked for an FDC ID if your food does not have one assigned.
 4. Make sure that every property you have created in Tandoor also has the corresponding FDC ID assigned so the matching can work.
 
 ## Usage
 1. Copy [appsettings.template.json](./appsettings.template.json) to `appsettings.json` and add your Tandoor endpoint as well as the API key to it.
-2. Run the program using `./tandoor_importer`.
+2. Run the program using `./tandoor_importer`. Refer to the [Parameters](#parameters) section for configuration.
 3. All food items for which a FDC ID was assigned should now have values for all your properties.
 
-## Logs
-By default, log level `error` is enabled. To run the program with a different log level please use:
-`RUST_LOG=tandoor_importer=info ./tandoor_importer` to set the log level to `info`.
-Replace `info` with the desired log level (`trace`, `debug`, `info`, `warn`, `error`)
+## Parameters
+
+### Flags
+| Name          | short name | Description                                                                 | Required? | Default |
+|---------------|------------|-----------------------------------------------------------------------------|-----------|---------|
+| --interactive | -i         | When set the program asks the user to provide an FDC ID when none was found | No        | false   |
+
+### Parameters with value
+| Name        | short name | Description                                                     | Required? | Default |
+|-------------|------------|-----------------------------------------------------------------|-----------|---------|
+| --log-level | -l         | Sets the log level [One of: trace, debug, info, warning, error] | No        | info    |

--- a/src/models/command_line_arguments.rs
+++ b/src/models/command_line_arguments.rs
@@ -11,7 +11,7 @@ pub struct Args{
     pub override_properties: bool,
 
     /// Interactive mode
-    #[arg(short, long, help = "When set the program asks the user to enter a FDC ID when none was found.")]
+    #[arg(short, long, help = "When set the program asks the user to provide an FDC ID when none was found.")]
     pub interactive: bool,
 
     /// Log level

--- a/src/models/tandoor/api_tandoor_food.rs
+++ b/src/models/tandoor/api_tandoor_food.rs
@@ -8,7 +8,9 @@ pub struct ApiTandoorFood {
     /// The name of the food item
     pub name: String,
     /// A list holding all [ApiTandoorFoodProperty] elements of the food item.
-    pub properties: Vec<ApiTandoorFoodProperty>
+    pub properties: Vec<ApiTandoorFoodProperty>,
+    /// The FDC ID of that food.
+    pub fdc_id: Option<i32>
 }
 
 impl From<InternalTandoorFood> for ApiTandoorFood{
@@ -16,6 +18,7 @@ impl From<InternalTandoorFood> for ApiTandoorFood{
         ApiTandoorFood{
             name: value.name,
             properties: value.properties.into_iter().map(|x| ApiTandoorFoodProperty::from(x)).collect(),
+            fdc_id: value.fdc_id
         }
     }
 }
@@ -25,6 +28,7 @@ impl From<&InternalTandoorFood> for ApiTandoorFood{
         ApiTandoorFood{
             name: value.name.to_string(),
             properties: value.properties.iter().map(|x| ApiTandoorFoodProperty::from(x.clone())).collect(),
+            fdc_id: value.fdc_id
         }
     }
 }


### PR DESCRIPTION
When no FDC ID can be found in the URL field or the FDC ID and the interactive mode is activated (starting program with `-i` flag) the user will be asked to enter a FDC ID.

- When the user enters a non valid id (not parseable to `u32`), he will be asked again.
- When the user enters a valid id, the entered id will be used to query the FDC database. If the request is valid (a food with that id was found), the food will be updated with the FDC id so the user will not be asked in the future.
- When the user leaves the field empty and just hits `Enter` no ID will be set and the food will be skipped.

Closes #6 