### PR TITLE
Implemented override mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # Tandoor Importer
 
 ## Description
-This is a nutrient importer for [Tandoor](https://tandoor.dev/), a open source recipe manager.
+This is a nutrient importer for [Tandoor](https://tandoor.dev/), an open source recipe manager.
 Tandoor has the possibility to add `Foods` which then can be used in recipes. For the different `Foods` properties like "Sugars", "Fats" or "Energy" can be added. 
 These will be used to calculate the total nutrients of a recipe.
-Because adding all the properties to a food by hand is quite annoying I built this importer to import data provided by the [USDA Food Database](https://fdc.nal.usda.gov/fdc-app.html#/food-search?query=&type=Foundation) using the [API](https://fdc.nal.usda.gov/api-spec/fdc_api.html).
-
-## Important
-- Note that all properties previously attached to a food are overwritten.
+Because adding all the properties to a food item by hand is quite annoying I built this importer to import data provided by the [USDA Food Database](https://fdc.nal.usda.gov/fdc-app.html#/food-search?query=&type=Foundation) using the [API](https://fdc.nal.usda.gov/api-spec/fdc_api.html).
 
 ## How does it work?
 1. The program reads the [appsettings.json](./appsettings.template.json) to find the Tandoor instance and to get the needed API-Keys for Tandoor and the USDA FDC database.
 2. After that all properties and all foods are retrieved from the Tandoor instance.
-3. For each food item retrieved from Tandoor the FDC ID of that food item (the ID is retrieved primarily from the "URL" field of a `Food`. If no URL is given the program tries to get it from the "FDC ID" field) is used to query the FDC database for nutrients.
+3. For each food item retrieved from Tandoor the FDC ID of that food item (the ID is retrieved primarily from the "URL" field of a `Food`. If no URL is given the program tries to get it from the "FDC ID" field, or asks the user if the program is run in interactive mode) is used to query the FDC database for nutrients.
 4. All nutrients of a food item are retrieved, then the nutrients that are not present in Tandoor are filtered out.
-5. The data retrieved from the FDC database is added to the Tandoor food. **Note that all properties previously associated with the Tandoor food are overwritten.**
+5. The data retrieved from the FDC database is added to the Tandoor food.
 6. The updated food is pushed to the Tandoor database.
 
 ## Prerequisites
@@ -30,7 +27,7 @@ Because adding all the properties to a food by hand is quite annoying I built th
 ## Usage
 1. Copy [appsettings.template.json](./appsettings.template.json) to `appsettings.json` and add your Tandoor endpoint as well as the API key to it.
 2. Run the program using `./tandoor_importer`. Refer to the [Parameters](#parameters) section for configuration.
-3. All food items for which a FDC ID was assigned should now have values for all your properties.
+3. All food items for which an FDC ID was assigned should now have values for all your properties.
 
 ## Parameters
 
@@ -38,6 +35,8 @@ Because adding all the properties to a food by hand is quite annoying I built th
 | Name          | short name | Description                                                                 | Required? | Default |
 |---------------|------------|-----------------------------------------------------------------------------|-----------|---------|
 | --interactive | -i         | When set the program asks the user to provide an FDC ID when none was found | No        | false   |
+| --override    | -o         | When set the program overrides properties that are already present.         | No        | false   |
+
 
 ### Parameters with value
 | Name        | short name | Description                                                     | Required? | Default |

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,16 @@ fn main(){
     let mut updated_foods: i32 = 0;
     let mut not_updated_foods: i32 = 0;
     let mut no_fdc_id: i32 = 0;
+    let mut already_fully_updated: i32 = 0;
     for mut food in tandoor_foods{
+        // Directly continue if number of properties of food is equal to number of properties
+        // retrieved from Tandoor and override is not enabled.
+        if !args.override_properties && food.properties.iter().count() == tandoor_properties.iter().count(){
+            info!("{} is already fully updated.", food.name);
+            already_fully_updated += 1;
+            continue;
+        }
+
         debug!("Going to update food {}", food.name);
         // Get data from USDA
         let fdc_id: i32;
@@ -137,7 +146,9 @@ fn main(){
         }
     }
     
-    info!("Updated {} foods. {} foods were not updated successfully. {} foods did not have a FDC ID.", updated_foods, not_updated_foods, no_fdc_id);
+    info!("Updated {} foods. \n {} foods were not updated successfully. \
+        \n {} foods did not have a FDC ID. \n {} foods were already completely updated.", 
+        updated_foods, not_updated_foods, no_fdc_id, already_fully_updated);
 }
 
 /// Gets all food properties of the Tandoor instance

--- a/src/models/tandoor/api_tandoor_food_property.rs
+++ b/src/models/tandoor/api_tandoor_food_property.rs
@@ -2,7 +2,6 @@
 use serde::{Serialize, Deserialize};
 use crate::models::tandoor::api_tandoor_property::ApiTandoorProperty;
 use crate::models::tandoor::internal_tandoor_food_property::InternalTandoorFoodProperty;
-use crate::models::usda::usda_nutrient::USDANutrient;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiTandoorFoodProperty {
@@ -17,17 +16,6 @@ impl From<InternalTandoorFoodProperty> for ApiTandoorFoodProperty{
         ApiTandoorFoodProperty{
             property_amount: value.property_amount.unwrap_or(0.0).to_string(),
             property_type: ApiTandoorProperty::from(value.property_type),
-        }
-    }
-}
-
-impl From<&USDANutrient> for ApiTandoorFoodProperty{
-    fn from(value: &USDANutrient) -> Self {
-         ApiTandoorFoodProperty {
-            property_amount: value.amount.unwrap_or(0.0).to_string(),
-            property_type: ApiTandoorProperty {
-                name: value.nutrient_information.name.to_string()
-            }
         }
     }
 }

--- a/src/models/tandoor/internal_tandoor_food.rs
+++ b/src/models/tandoor/internal_tandoor_food.rs
@@ -2,7 +2,7 @@
 use serde::{Serialize, Deserialize};
 use crate::models::tandoor::internal_tandoor_food_property::InternalTandoorFoodProperty;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InternalTandoorFood {
     /// The id of the food item.
     pub id: i32,

--- a/src/models/tandoor/internal_tandoor_food_property.rs
+++ b/src/models/tandoor/internal_tandoor_food_property.rs
@@ -2,10 +2,24 @@
 use serde::{Serialize, Deserialize};
 
 use crate::models::tandoor::internal_tandoor_property::InternalTandoorProperty;
+use crate::models::usda::usda_nutrient::USDANutrient;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InternalTandoorFoodProperty {
     /// How much of the property is in that food.
     pub property_amount: Option<f32>,
     /// Definition of the property that is in that food.
     pub property_type: InternalTandoorProperty
+}
+
+impl From<&USDANutrient> for InternalTandoorFoodProperty{
+    fn from(value: &USDANutrient) -> Self {
+        InternalTandoorFoodProperty {
+            property_amount: value.amount,
+            property_type: InternalTandoorProperty {
+                name: value.nutrient_information.name.to_string(),
+                fdc_id: value.nutrient_information.id
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #9.

Breaking change as the program does not override data by default anymore. 
If nothing is specified only properties that are not already present will be added.
When a food item already has all properties defined in Tandoor it will be skipped immediately and no data will be requested from the FDC database.
If all properties should be updated start the program with `--override` enabled. 